### PR TITLE
Increase Length of Position_Title__c

### DIFF
--- a/force-app/main/default/objects/Job_Application__c/fields/Position_Title__c.field-meta.xml
+++ b/force-app/main/default/objects/Job_Application__c/fields/Position_Title__c.field-meta.xml
@@ -5,7 +5,7 @@
     <externalId>false</externalId>
     <inlineHelpText>Enter the position name or job title.</inlineHelpText>
     <label>Position/Title</label>
-    <length>99</length>
+    <length>255</length>
     <required>false</required>
     <trackHistory>false</trackHistory>
     <trackTrending>false</trackTrending>


### PR DESCRIPTION
Length had to be increased to 255 to avoid Jooble job titles longer than 99 causing issues.